### PR TITLE
scripts: twister: apply sharing builds mechanism

### DIFF
--- a/samples/bluetooth/pytest/test_central_and_peripheral.py
+++ b/samples/bluetooth/pytest/test_central_and_peripheral.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+def test_dummy():
+    assert True

--- a/samples/bluetooth/testcase.yaml
+++ b/samples/bluetooth/testcase.yaml
@@ -1,0 +1,16 @@
+common:
+  platform_allow:
+    - qemu_cortex_m3
+  harness: pytest
+  tags: bluetooth
+
+tests:
+  bluetooth.central_and_peripheral_hr:
+    required_images:
+      - sample.bluetooth.central
+      - sample.bluetooth.peripheral_hr
+
+  bluetooth.central_and_peripheral_ht:
+    required_images:
+      - sample.bluetooth.central
+      - sample.bluetooth.peripheral_ht

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -49,6 +49,7 @@ class TwisterConfigParser:
                        "extra_conf_files": {"type": "list", "default": []},
                        "extra_overlay_confs" : {"type": "list", "default": []},
                        "extra_dtc_overlay_files": {"type": "list", "default": []},
+                       "required_images": {"type": "list"},
                        "required_snippets": {"type": "list"},
                        "build_only": {"type": "bool", "default": False},
                        "build_on_all": {"type": "bool", "default": False},

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -151,6 +151,11 @@ mapping:
         matching: "all"
         sequence:
           - type: str
+      "required_images":
+        type: seq
+        required: false
+        sequence:
+          - type: str
       "required_snippets":
         type: seq
         required: false
@@ -255,6 +260,11 @@ mapping:
             type: any
             required: false
           "required_snippets":
+            type: seq
+            required: false
+            sequence:
+              - type: str
+          "required_images":
             type: seq
             required: false
             sequence:


### PR DESCRIPTION
To run:

```
./scripts/twister -vv --inline-logs -p qemu_cortex_m3 -T samples/bluetooth/ -s samples/bluetooth/bluetooth.central_and_peripheral_hr -s samples/bluetooth/bluetooth.central_and_peripheral_ht
```
After running those two tests (`bluetooth.central_and_peripheral_hr` and `bluetooth.central_and_peripheral_ht`) it can be observed, that Twister adds automatically `sample.bluetooth.central`, `sample.bluetooth.peripheral_hr` and `sample.bluetooth.peripheral_ht`. Sharing builds mechanism works, because `sample.bluetooth.central` was build only once and is "shared" between `bluetooth.central_and_peripheral_hr` and `bluetooth.central_and_peripheral_ht`.


Assumpitons:
- `required_images` are placed in subfolder of "parent" testcase.yaml
- no errors during building
- `required_images` have the same platform filtration as "parent" - no skips during generation test plan and during building
- "parent" test scenario does not build its own image (just wait for building `required_images`)
- "parent" test scenario perform "dummy" test (no flashing, etc.)
- no `--subset`

Questions and issues:

General:
---

- If test scenario in testcase.yaml file has `required_images`, then should be there possibility to build application for this test itself?
- What about gathering memory metrics - has it sense for test scenarios with `required_images`?
- What about checking coverage - has it sense for test scenarios with `required_images`?

In `testplan.py`
---

TestPlan.add_testsuites():
- Add possibility to add test scenarios outside of test_root (-T)
- scan_testsuite_path(suite_path) - should be applied in test scenario which contains 'required_images' entry? Is there any sense to look for ZTest testcases?

quarantine:
- What to do when one of required_images is on quarantine? The "parent" test scenario should be also quarantined automatically?

TestPlan.load():
- How to deal with loading test scope from files (--only-failed) or --test-only? What if --only-failed will be applied and one of 'required_images' failed? Should be both of them rebuild or not?

TestPlan.generate_subset():
- subsets - there should be additional logic to avoid situation when 'required_images' will be assigned to separate subsets. Moreover, this requires additional logic to "balance" somehow number of tests in subsets.

TestPlan.apply_filters():
- What about creating TestInstances -> what about selecting platforms per test scenario. In current proposition, when in "parent" testcase.yaml is "integration_platforms: plat_A" and in "child" testcase.yaml is "integration_platforms: plat_A, plat_B", and user would like to run only "parent" test scenario with integration mode (-G), then "child" test scenario will be build both for plat_A and plat_B (should be build only for plat_A as in "parent" test scenario)
- How platform scope of "required_images" should be chosen? Should be inherited from "parent" test scenario? If yes, than this requires additional logic to distinguish situation when only parent include "required_images" and when "required_images" are intentionally chosen by user.
- What in situation when one of "required_images" is filtered out? To handle it properly we should iterate once again through "test_instances" and filter out "parent" instances which base on those image. Otherwise, there is a risk, that "parent" test instances will be waiting for images which will never be built.
- What about testsuite_filter (-s)? How to deal with this?
- What about "platform_key"? They reduce the number of tests, but with "required_images" it requires more sophisticated method, to avoid situation when one of "required_image" is skipped due to the "platform_key". Or just forbid using "required_images" with "platform_key".

TestPlan.find_subsets():
- Is "--sub-test" used anywhere? From doc: "Recursively find sub-test functions and run the entire test section where they were found, including all sibling test functions.". How to deal with image sharing mechanism? Should "parent" test scenario (which contains 'required_images' entry) be involved in this searching? Has this any sense?

In `runner.py`
---

ProjectBuilder.process():
- In each place where testinstace.status ('filtered', 'failed', 'error', 'pass') is changed, then there should be added update in `twister_builder.json` file - `self.build_manager.update_status(self.instance.testsuite.id, BuildStatus.*)`
- When building in "required_images" is compleated, then the build directories should be copied to "parent" test instance.
- What about gathering metrics and cleanup artifacts for test instances with "required_images"? When "children" application will be copied to "parent" build dir, then cleanup artifacts mechanism need additional changes.

TwisterRunner.run():
- Retry build errors requires additional mechanism to rerun test instances in proper order (`required_images` at first).

TwisterRunner.sort_instances():
- This way of sorting (putting testscenarios with `required_images` to the end of queue is not so effective - some of those tests could be executed earlier (when their particular `requred_images` will be built). Otherwise those tests have to wait for finishing building all "children" applications. This is similar to call Twister at first with `--build-only` and then call it separately with `--test-only`.
